### PR TITLE
Role-based login with separate screens

### DIFF
--- a/lib/views/admin/admin_home_screen.dart
+++ b/lib/views/admin/admin_home_screen.dart
@@ -1,0 +1,13 @@
+import 'package:flutter/material.dart';
+
+class AdminHomeScreen extends StatelessWidget {
+  const AdminHomeScreen({Key? key}) : super(key: key);
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: const Text('Admin Home')),
+      body: const Center(child: Text('Welcome, Admin!')),
+    );
+  }
+}

--- a/lib/views/manager/manager_home_screen.dart
+++ b/lib/views/manager/manager_home_screen.dart
@@ -1,0 +1,13 @@
+import 'package:flutter/material.dart';
+
+class ManagerHomeScreen extends StatelessWidget {
+  const ManagerHomeScreen({Key? key}) : super(key: key);
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: const Text('Manager Home')),
+      body: const Center(child: Text('Welcome, Manager')),
+    );
+  }
+}

--- a/lib/views/staff/staff_home_screen.dart
+++ b/lib/views/staff/staff_home_screen.dart
@@ -1,0 +1,13 @@
+import 'package:flutter/material.dart';
+
+class StaffHomeScreen extends StatelessWidget {
+  const StaffHomeScreen({Key? key}) : super(key: key);
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: const Text('Staff Home')),
+      body: const Center(child: Text('Welcome, Staff')),
+    );
+  }
+}


### PR DESCRIPTION
## Description:
- Integrated role-based login redirection logic in the main app, routing users based on Firestore role: Admin, Manager, or Staff.
- Ensured login screen is shown only to unauthenticated users. Role detection and navigation happen automatically after login.
- Added separate screen folders for `admin`, `manager`, and `staff` dashboards to organize the codebase.

## Changes Made:
- Updated `main.dart` to include `StreamBuilder` for auth state and `FutureBuilder` for user role.
- Modified `login_screen.dart` to support role-based logic.
- Created separate folder structures and dummy screens for each role.
- Improved maintainability and clarity of login flow.

## Impact:
- Makes future development for role-specific features easier.
- Prevents incorrect navigation or screen access based on user roles.
- Boosts code modularity and scalability as more roles/features are added.

## Tested: Yes 
- Logged in as Admin, Manager, and Staff and verified correct navigation.
- Confirmed login screen appears when not authenticated.
- Checked fallback handling for missing or unknown roles.
